### PR TITLE
feat: 体重記録機能を実装

### DIFF
--- a/backend/database/migrations/004_create_weight_logs_table.sql
+++ b/backend/database/migrations/004_create_weight_logs_table.sql
@@ -1,0 +1,19 @@
+-- 体重記録テーブル
+CREATE TABLE weight_logs (
+    id BIGSERIAL PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    weight DOUBLE PRECISION NOT NULL,
+    logged_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- インデックス
+CREATE INDEX idx_weight_logs_user_id ON weight_logs(user_id);
+CREATE INDEX idx_weight_logs_logged_at ON weight_logs(logged_at);
+CREATE INDEX idx_weight_logs_user_logged_at ON weight_logs(user_id, logged_at);
+
+-- コメント
+COMMENT ON TABLE weight_logs IS 'ユーザーの体重記録';
+COMMENT ON COLUMN weight_logs.weight IS '体重 (kg)';
+COMMENT ON COLUMN weight_logs.logged_at IS '記録日時';

--- a/backend/internal/bff/resolvers/schema.resolvers.go
+++ b/backend/internal/bff/resolvers/schema.resolvers.go
@@ -282,6 +282,31 @@ func (r *mutationResolver) LogExercise(ctx context.Context, input backend.LogExe
 	}, nil
 }
 
+// LogWeight is the resolver for the logWeight field.
+func (r *mutationResolver) LogWeight(ctx context.Context, weight float64, date string) (*backend.WeightLog, error) {
+	// TODO: コンテキストから実際のユーザーIDを取得
+	userID := "550e8400-e29b-41d4-a716-446655440000"
+
+	// 入力型をサービス層の型に変換
+	serviceInput := log.LogWeightInput{
+		Weight: weight,
+		Date:   date,
+	}
+
+	// LogServiceを呼び出す
+	logID, err := r.Resolver.LogService.LogWeight(ctx, userID, serviceInput)
+	if err != nil {
+		return nil, err
+	}
+
+	// 成功レスポンスを返す
+	return &backend.WeightLog{
+		ID:       fmt.Sprintf("%d", logID),
+		Weight:   weight,
+		LoggedAt: date,
+	}, nil
+}
+
 // SearchFood is the resolver for the searchFood field.
 func (r *queryResolver) SearchFood(ctx context.Context, query string) ([]*backend.Food, error) {
 	// FoodDataServiceを呼び出す

--- a/backend/internal/service/log/service.go
+++ b/backend/internal/service/log/service.go
@@ -55,10 +55,24 @@ type ExerciseLog struct {
 	LoggedAt        string
 }
 
+// LogWeightInputは体重記録の入力です
+type LogWeightInput struct {
+	Weight float64
+	Date   string
+}
+
+// WeightLogは体重記録を表します
+type WeightLog struct {
+	ID       int64
+	Weight   float64
+	LoggedAt string
+}
+
 // Serviceは記録関連のビジネスロジックのインターフェースです
 type Service interface {
 	LogExercise(ctx context.Context, userID string, input LogExerciseInput) (int64, error)
 	LogFood(ctx context.Context, userID string, input LogFoodInput) (int64, error)
+	LogWeight(ctx context.Context, userID string, input LogWeightInput) (int64, error)
 	GetDailySummary(ctx context.Context, userID, date string) (DailySummary, error)
 	GetFoodLogs(ctx context.Context, userID, date string) ([]FoodLog, error)
 	GetExerciseLogs(ctx context.Context, userID, date string) ([]ExerciseLog, error)
@@ -179,6 +193,20 @@ func (s *service) GetFoodLogs(ctx context.Context, userID, date string) ([]FoodL
 	return logs, nil
 }
 
+// LogWeightは体重記録をデータベースに保存します
+func (s *service) LogWeight(ctx context.Context, userID string, in LogWeightInput) (int64, error) {
+	const q = `
+		INSERT INTO weight_logs (user_id, weight, logged_at)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`
+	var id int64
+	if err := s.db.QueryRowContext(ctx, q, userID, in.Weight, in.Date).Scan(&id); err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
 // GetExerciseLogsは指定された日付の運動記録を取得します
 func (s *service) GetExerciseLogs(ctx context.Context, userID, date string) ([]ExerciseLog, error) {
 	const q = `
@@ -215,4 +243,18 @@ func (s *service) GetExerciseLogs(ctx context.Context, userID, date string) ([]E
 	}
 
 	return logs, nil
+}
+
+// LogWeightは体重記録をデータベースに保存します
+func (s *service) LogWeight(ctx context.Context, userID string, in LogWeightInput) (int64, error) {
+	const q = `
+		INSERT INTO weight_logs (user_id, weight, logged_at)
+		VALUES ($1, $2, $3)
+		RETURNING id
+	`
+	var id int64
+	if err := s.db.QueryRowContext(ctx, q, userID, in.Weight, in.Date).Scan(&id); err != nil {
+		return 0, err
+	}
+	return id, nil
 }

--- a/backend/schema.graphql
+++ b/backend/schema.graphql
@@ -46,6 +46,9 @@ type Mutation {
 
   "運動を記録します (消費カロリーは手動入力)"
   logExercise(input: LogExerciseInput!): ExerciseLog! @auth
+
+  "体重を記録します"
+  logWeight(weight: Float!, date: String!): WeightLog! @auth
 }
 
 type User {
@@ -100,6 +103,13 @@ type ExerciseLog {
   exerciseName: String!
   durationMinutes: Int!
   caloriesBurned: Float!
+  loggedAt: String!
+}
+
+"体重記録を表す型"
+type WeightLog {
+  id: ID!
+  weight: Float!
   loggedAt: String!
 }
 

--- a/frontend/src/features/dashboard/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/DashboardPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useQuery } from '@apollo/client';
 import { FoodLogModal } from '../records/FoodLogModal';
 import { ExerciseLogModal } from '../records/ExerciseLogModal';
+import { WeightLogModal } from '../records/WeightLogModal';
 import { DailySummaryNumbers } from '../../components/DailySummaryNumbers';
 import { PFCProgressBars } from '../../components/PFCProgressBars';
 import { DateNavigator } from '../../components/DateNavigator';
@@ -13,6 +14,7 @@ import { useAuth } from '../../contexts/AuthContext';
 export const DashboardPage = () => {
   const [isFoodModalOpen, setFoodModalOpen] = useState(false);
   const [isExerciseModalOpen, setExerciseModalOpen] = useState(false);
+  const [isWeightModalOpen, setWeightModalOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0]);
 
   const { user, signOut } = useAuth();
@@ -93,6 +95,13 @@ export const DashboardPage = () => {
             icon: '🏃',
             onClick: () => setExerciseModalOpen(true),
             color: '#2196F3'
+          },
+          {
+            id: 'weight',
+            label: '体重を記録',
+            icon: '📏',
+            onClick: () => setWeightModalOpen(true),
+            color: '#4CAF50'
           }
         ]}
         mainIcon="+"
@@ -102,6 +111,7 @@ export const DashboardPage = () => {
       {/* モーダル */}
       <FoodLogModal isOpen={isFoodModalOpen} onClose={() => setFoodModalOpen(false)} logDate={selectedDate} />
       <ExerciseLogModal isOpen={isExerciseModalOpen} onClose={() => setExerciseModalOpen(false)} logDate={selectedDate} />
+      <WeightLogModal isOpen={isWeightModalOpen} onClose={() => setWeightModalOpen(false)} logDate={selectedDate} />
     </div>
   );
 };

--- a/frontend/src/features/records/WeightLogModal.tsx
+++ b/frontend/src/features/records/WeightLogModal.tsx
@@ -1,0 +1,216 @@
+import React, { useState } from 'react';
+import { useMutation } from '@apollo/client';
+import { LOG_WEIGHT_MUTATION } from '../../graphql/queries';
+
+type Props = {
+  isOpen: boolean;
+  onClose: () => void;
+  logDate: string;
+};
+
+export const WeightLogModal = ({ isOpen, onClose, logDate }: Props) => {
+  const [weight, setWeight] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [logWeight] = useMutation(LOG_WEIGHT_MUTATION, {
+    onCompleted: () => {
+      setIsSubmitting(false);
+      onClose();
+      setWeight('');
+    },
+    onError: (error) => {
+      console.error('体重記録エラー:', error);
+      setIsSubmitting(false);
+      alert('体重の記録に失敗しました。もう一度お試しください。');
+    },
+  });
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    
+    if (!weight || parseFloat(weight) <= 0) {
+      alert('有効な体重を入力してください。');
+      return;
+    }
+
+    setIsSubmitting(true);
+    
+    try {
+      await logWeight({
+        variables: {
+          weight: parseFloat(weight),
+          date: logDate,
+        },
+      });
+    } catch (error) {
+      console.error('体重記録エラー:', error);
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleClose = () => {
+    if (!isSubmitting) {
+      onClose();
+      setWeight('');
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1000
+    }}>
+      <div style={{
+        backgroundColor: 'white',
+        borderRadius: '12px',
+        padding: '24px',
+        width: '90%',
+        maxWidth: '400px',
+        boxShadow: '0 10px 25px rgba(0, 0, 0, 0.2)'
+      }}>
+        {/* ヘッダー */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          marginBottom: '20px'
+        }}>
+          <h2 style={{
+            margin: 0,
+            fontSize: '20px',
+            fontWeight: '600',
+            color: '#333'
+          }}>
+            📏 体重記録
+          </h2>
+          <button
+            onClick={handleClose}
+            disabled={isSubmitting}
+            style={{
+              background: 'none',
+              border: 'none',
+              fontSize: '24px',
+              cursor: isSubmitting ? 'not-allowed' : 'pointer',
+              color: '#666',
+              opacity: isSubmitting ? 0.5 : 1
+            }}
+          >
+            ×
+          </button>
+        </div>
+
+        {/* フォーム */}
+        <form onSubmit={handleSubmit}>
+          <div style={{ marginBottom: '20px' }}>
+            <label style={{
+              display: 'block',
+              marginBottom: '8px',
+              fontSize: '14px',
+              fontWeight: '500',
+              color: '#555'
+            }}>
+              体重 (kg)
+            </label>
+            <input
+              type="number"
+              step="0.1"
+              min="0"
+              max="300"
+              value={weight}
+              onChange={(e) => setWeight(e.target.value)}
+              placeholder="例: 65.5"
+              disabled={isSubmitting}
+              style={{
+                width: '100%',
+                padding: '12px',
+                border: '2px solid #e1e5e9',
+                borderRadius: '8px',
+                fontSize: '16px',
+                outline: 'none',
+                transition: 'border-color 0.2s',
+                opacity: isSubmitting ? 0.6 : 1
+              }}
+              onFocus={(e) => {
+                e.target.style.borderColor = '#4CAF50';
+              }}
+              onBlur={(e) => {
+                e.target.style.borderColor = '#e1e5e9';
+              }}
+            />
+          </div>
+
+          {/* 記録日表示 */}
+          <div style={{
+            marginBottom: '20px',
+            padding: '12px',
+            backgroundColor: '#f8f9fa',
+            borderRadius: '8px',
+            fontSize: '14px',
+            color: '#666'
+          }}>
+            📅 記録日: {new Date(logDate).toLocaleDateString('ja-JP', {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric'
+            })}
+          </div>
+
+          {/* ボタン */}
+          <div style={{
+            display: 'flex',
+            gap: '12px'
+          }}>
+            <button
+              type="button"
+              onClick={handleClose}
+              disabled={isSubmitting}
+              style={{
+                flex: 1,
+                padding: '12px',
+                border: '2px solid #e1e5e9',
+                borderRadius: '8px',
+                backgroundColor: 'white',
+                color: '#666',
+                fontSize: '16px',
+                fontWeight: '500',
+                cursor: isSubmitting ? 'not-allowed' : 'pointer',
+                opacity: isSubmitting ? 0.5 : 1,
+                transition: 'all 0.2s'
+              }}
+            >
+              キャンセル
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting || !weight}
+              style={{
+                flex: 1,
+                padding: '12px',
+                border: 'none',
+                borderRadius: '8px',
+                backgroundColor: isSubmitting || !weight ? '#ccc' : '#4CAF50',
+                color: 'white',
+                fontSize: '16px',
+                fontWeight: '500',
+                cursor: isSubmitting || !weight ? 'not-allowed' : 'pointer',
+                transition: 'background-color 0.2s'
+              }}
+            >
+              {isSubmitting ? '記録中...' : '記録する'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -39,3 +39,13 @@ export const GET_EXERCISE_LOGS_QUERY = gql`
     }
   }
 `;
+
+export const LOG_WEIGHT_MUTATION = gql`
+  mutation LogWeight($weight: Float!, $date: String!) {
+    logWeight(weight: $weight, date: $date) {
+      id
+      weight
+      loggedAt
+    }
+  }
+`;


### PR DESCRIPTION
## 概要
ユーザーが日々の体重を記録できる機能を実装しました。FloatingActionButtonから体重記録モーダルを開き、体重を入力して記録できます。

## 実装内容

### バックエンド
- `weight_logs`テーブルのマイグレーションを追加
- GraphQLスキーマに`logWeight`ミューテーションと`WeightLog`型を追加
- LogServiceに`LogWeight`メソッドを実装
- 体重記録のリゾルバーを追加
- 日付指定での体重記録機能を実装

### フロントエンド
- `LOG_WEIGHT_MUTATION`を追加
- `WeightLogModal`コンポーネントを実装
- 体重入力フォームとバリデーション機能を追加
- FloatingActionButtonに体重記録アクションを追加
- ダッシュボードに体重記録機能を統合
- エラーハンドリングとローディング状態を実装

## 技術的詳細
- **データベース**: PostgreSQLの`weight_logs`テーブル
- **API**: GraphQLミューテーション（`logWeight`）
- **UI**: React + TypeScript、Apollo Client
- **バリデーション**: 体重の数値チェック（0-300kg）
- **エラーハンドリング**: 適切なエラーメッセージとローディング状態

## 機能仕様
- 📏 体重をkg単位で入力（小数点第1位まで）
- 📅 日付指定での記録（デフォルトは選択中の日付）
- ✅ 入力値のバリデーション（0より大きく300以下）
- ⚠️ エラー時の適切なフィードバック
- 記録中のローディング状態表示

## テスト
- [ ] 体重記録モーダルが正常に開閉することを確認
- [ ] 有効な体重値で記録が成功することを確認
- [ ] 無効な体重値でバリデーションエラーが表示されることを確認
- [ ] エラー時の適切なメッセージが表示されることを確認

## 関連Issue
- 体重記録機能の実装
- 残りの未実装機能の完了

## 備考
- 設計書の仕様通りに実装
- 既存のUIデザインと統一されたスタイル
- 他の記録機能（食事・運動）と同様のUX
- 日付ナビゲーターとの連携で選択日付に記録