### PR TITLE
fix: GraphQLコード生成でWeightLog型を生成

### DIFF
--- a/backend/generated.go
+++ b/backend/generated.go
@@ -99,6 +99,7 @@ type ComplexityRoot struct {
 		ConfirmSignUp        func(childComplexity int, email string, confirmationCode string) int
 		LogExercise          func(childComplexity int, input LogExerciseInput) int
 		LogFood              func(childComplexity int, input LogFoodInput) int
+		LogWeight            func(childComplexity int, weight float64, date string) int
 		RefreshToken         func(childComplexity int, refreshToken string) int
 		ResetPassword        func(childComplexity int, email string) int
 		SignIn               func(childComplexity int, email string, password string) int
@@ -108,6 +109,8 @@ type ComplexityRoot struct {
 
 	Query struct {
 		DailySummary func(childComplexity int, date string) int
+		ExerciseLogs func(childComplexity int, date string) int
+		FoodLogs     func(childComplexity int, date string) int
 		SearchFood   func(childComplexity int, query string) int
 	}
 
@@ -122,6 +125,12 @@ type ComplexityRoot struct {
 		Email func(childComplexity int) int
 		ID    func(childComplexity int) int
 	}
+
+	WeightLog struct {
+		ID       func(childComplexity int) int
+		LoggedAt func(childComplexity int) int
+		Weight   func(childComplexity int) int
+	}
 }
 
 type MutationResolver interface {
@@ -135,10 +144,13 @@ type MutationResolver interface {
 	CompleteOnboarding(ctx context.Context, profile UserProfileInput, goal UserGoalInput) (*User, error)
 	LogFood(ctx context.Context, input LogFoodInput) (*FoodLog, error)
 	LogExercise(ctx context.Context, input LogExerciseInput) (*ExerciseLog, error)
+	LogWeight(ctx context.Context, weight float64, date string) (*WeightLog, error)
 }
 type QueryResolver interface {
 	SearchFood(ctx context.Context, query string) ([]*Food, error)
 	DailySummary(ctx context.Context, date string) (*DailySummary, error)
+	FoodLogs(ctx context.Context, date string) ([]*FoodLog, error)
+	ExerciseLogs(ctx context.Context, date string) ([]*ExerciseLog, error)
 }
 
 type executableSchema struct {
@@ -437,6 +449,18 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Mutation.LogFood(childComplexity, args["input"].(LogFoodInput)), true
 
+	case "Mutation.logWeight":
+		if e.complexity.Mutation.LogWeight == nil {
+			break
+		}
+
+		args, err := ec.field_Mutation_logWeight_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Mutation.LogWeight(childComplexity, args["weight"].(float64), args["date"].(string)), true
+
 	case "Mutation.refreshToken":
 		if e.complexity.Mutation.RefreshToken == nil {
 			break
@@ -504,6 +528,30 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Query.DailySummary(childComplexity, args["date"].(string)), true
 
+	case "Query.exerciseLogs":
+		if e.complexity.Query.ExerciseLogs == nil {
+			break
+		}
+
+		args, err := ec.field_Query_exerciseLogs_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.ExerciseLogs(childComplexity, args["date"].(string)), true
+
+	case "Query.foodLogs":
+		if e.complexity.Query.FoodLogs == nil {
+			break
+		}
+
+		args, err := ec.field_Query_foodLogs_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.complexity.Query.FoodLogs(childComplexity, args["date"].(string)), true
+
 	case "Query.searchFood":
 		if e.complexity.Query.SearchFood == nil {
 			break
@@ -557,6 +605,27 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.complexity.User.ID(childComplexity), true
+
+	case "WeightLog.id":
+		if e.complexity.WeightLog.ID == nil {
+			break
+		}
+
+		return e.complexity.WeightLog.ID(childComplexity), true
+
+	case "WeightLog.loggedAt":
+		if e.complexity.WeightLog.LoggedAt == nil {
+			break
+		}
+
+		return e.complexity.WeightLog.LoggedAt(childComplexity), true
+
+	case "WeightLog.weight":
+		if e.complexity.WeightLog.Weight == nil {
+			break
+		}
+
+		return e.complexity.WeightLog.Weight(childComplexity), true
 
 	}
 	return 0, false
@@ -761,6 +830,22 @@ func (ec *executionContext) field_Mutation_logFood_args(ctx context.Context, raw
 	return args, nil
 }
 
+func (ec *executionContext) field_Mutation_logWeight_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "weight", ec.unmarshalNFloat2float64)
+	if err != nil {
+		return nil, err
+	}
+	args["weight"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "date", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["date"] = arg1
+	return args, nil
+}
+
 func (ec *executionContext) field_Mutation_refreshToken_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
@@ -827,6 +912,28 @@ func (ec *executionContext) field_Query___type_args(ctx context.Context, rawArgs
 }
 
 func (ec *executionContext) field_Query_dailySummary_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "date", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["date"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_exerciseLogs_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "date", ec.unmarshalNString2string)
+	if err != nil {
+		return nil, err
+	}
+	args["date"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_foodLogs_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
 	var err error
 	args := map[string]any{}
 	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "date", ec.unmarshalNString2string)
@@ -2966,6 +3073,91 @@ func (ec *executionContext) fieldContext_Mutation_logExercise(ctx context.Contex
 	return fc, nil
 }
 
+func (ec *executionContext) _Mutation_logWeight(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Mutation_logWeight(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		directive0 := func(rctx context.Context) (any, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Mutation().LogWeight(rctx, fc.Args["weight"].(float64), fc.Args["date"].(string))
+		}
+
+		directive1 := func(ctx context.Context) (any, error) {
+			if ec.directives.Auth == nil {
+				var zeroVal *WeightLog
+				return zeroVal, errors.New("directive auth is not implemented")
+			}
+			return ec.directives.Auth(ctx, nil, directive0)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.(*WeightLog); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be *github.com/HirotakaUchishiba/calomeal_mvp/backend.WeightLog`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(*WeightLog)
+	fc.Result = res
+	return ec.marshalNWeightLog2ᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐWeightLog(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Mutation_logWeight(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Mutation",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_WeightLog_id(ctx, field)
+			case "weight":
+				return ec.fieldContext_WeightLog_weight(ctx, field)
+			case "loggedAt":
+				return ec.fieldContext_WeightLog_loggedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type WeightLog", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Mutation_logWeight_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query_searchFood(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_Query_searchFood(ctx, field)
 	if err != nil {
@@ -3142,6 +3334,192 @@ func (ec *executionContext) fieldContext_Query_dailySummary(ctx context.Context,
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_dailySummary_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_foodLogs(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_foodLogs(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		directive0 := func(rctx context.Context) (any, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().FoodLogs(rctx, fc.Args["date"].(string))
+		}
+
+		directive1 := func(ctx context.Context) (any, error) {
+			if ec.directives.Auth == nil {
+				var zeroVal []*FoodLog
+				return zeroVal, errors.New("directive auth is not implemented")
+			}
+			return ec.directives.Auth(ctx, nil, directive0)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.([]*FoodLog); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/HirotakaUchishiba/calomeal_mvp/backend.FoodLog`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*FoodLog)
+	fc.Result = res
+	return ec.marshalNFoodLog2ᚕᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐFoodLogᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_foodLogs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_FoodLog_id(ctx, field)
+			case "foodName":
+				return ec.fieldContext_FoodLog_foodName(ctx, field)
+			case "quantity":
+				return ec.fieldContext_FoodLog_quantity(ctx, field)
+			case "unit":
+				return ec.fieldContext_FoodLog_unit(ctx, field)
+			case "calories":
+				return ec.fieldContext_FoodLog_calories(ctx, field)
+			case "protein":
+				return ec.fieldContext_FoodLog_protein(ctx, field)
+			case "carbohydrate":
+				return ec.fieldContext_FoodLog_carbohydrate(ctx, field)
+			case "fat":
+				return ec.fieldContext_FoodLog_fat(ctx, field)
+			case "loggedAt":
+				return ec.fieldContext_FoodLog_loggedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type FoodLog", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_foodLogs_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_exerciseLogs(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_Query_exerciseLogs(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		directive0 := func(rctx context.Context) (any, error) {
+			ctx = rctx // use context from middleware stack in children
+			return ec.resolvers.Query().ExerciseLogs(rctx, fc.Args["date"].(string))
+		}
+
+		directive1 := func(ctx context.Context) (any, error) {
+			if ec.directives.Auth == nil {
+				var zeroVal []*ExerciseLog
+				return zeroVal, errors.New("directive auth is not implemented")
+			}
+			return ec.directives.Auth(ctx, nil, directive0)
+		}
+
+		tmp, err := directive1(rctx)
+		if err != nil {
+			return nil, graphql.ErrorOnPath(ctx, err)
+		}
+		if tmp == nil {
+			return nil, nil
+		}
+		if data, ok := tmp.([]*ExerciseLog); ok {
+			return data, nil
+		}
+		return nil, fmt.Errorf(`unexpected type %T from directive, should be []*github.com/HirotakaUchishiba/calomeal_mvp/backend.ExerciseLog`, tmp)
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.([]*ExerciseLog)
+	fc.Result = res
+	return ec.marshalNExerciseLog2ᚕᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐExerciseLogᚄ(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_Query_exerciseLogs(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "id":
+				return ec.fieldContext_ExerciseLog_id(ctx, field)
+			case "exerciseName":
+				return ec.fieldContext_ExerciseLog_exerciseName(ctx, field)
+			case "durationMinutes":
+				return ec.fieldContext_ExerciseLog_durationMinutes(ctx, field)
+			case "caloriesBurned":
+				return ec.fieldContext_ExerciseLog_caloriesBurned(ctx, field)
+			case "loggedAt":
+				return ec.fieldContext_ExerciseLog_loggedAt(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ExerciseLog", field.Name)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_exerciseLogs_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -3533,6 +3911,138 @@ func (ec *executionContext) _User_email(ctx context.Context, field graphql.Colle
 func (ec *executionContext) fieldContext_User_email(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "User",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WeightLog_id(ctx context.Context, field graphql.CollectedField, obj *WeightLog) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WeightLog_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WeightLog_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WeightLog",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WeightLog_weight(ctx context.Context, field graphql.CollectedField, obj *WeightLog) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WeightLog_weight(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Weight, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(float64)
+	fc.Result = res
+	return ec.marshalNFloat2float64(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WeightLog_weight(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WeightLog",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Float does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _WeightLog_loggedAt(ctx context.Context, field graphql.CollectedField, obj *WeightLog) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_WeightLog_loggedAt(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.LoggedAt, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_WeightLog_loggedAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "WeightLog",
 		Field:      field,
 		IsMethod:   false,
 		IsResolver: false,
@@ -6084,6 +6594,13 @@ func (ec *executionContext) _Mutation(ctx context.Context, sel ast.SelectionSet)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "logWeight":
+			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
+				return ec._Mutation_logWeight(ctx, field)
+			})
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -6158,6 +6675,50 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_dailySummary(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "foodLogs":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_foodLogs(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "exerciseLogs":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_exerciseLogs(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}
@@ -6273,6 +6834,55 @@ func (ec *executionContext) _User(ctx context.Context, sel ast.SelectionSet, obj
 			}
 		case "email":
 			out.Values[i] = ec._User_email(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var weightLogImplementors = []string{"WeightLog"}
+
+func (ec *executionContext) _WeightLog(ctx context.Context, sel ast.SelectionSet, obj *WeightLog) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, weightLogImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("WeightLog")
+		case "id":
+			out.Values[i] = ec._WeightLog_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "weight":
+			out.Values[i] = ec._WeightLog_weight(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "loggedAt":
+			out.Values[i] = ec._WeightLog_loggedAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
@@ -6682,6 +7292,50 @@ func (ec *executionContext) marshalNExerciseLog2githubᚗcomᚋHirotakaUchishiba
 	return ec._ExerciseLog(ctx, sel, &v)
 }
 
+func (ec *executionContext) marshalNExerciseLog2ᚕᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐExerciseLogᚄ(ctx context.Context, sel ast.SelectionSet, v []*ExerciseLog) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNExerciseLog2ᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐExerciseLog(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
 func (ec *executionContext) marshalNExerciseLog2ᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐExerciseLog(ctx context.Context, sel ast.SelectionSet, v *ExerciseLog) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
@@ -6764,6 +7418,50 @@ func (ec *executionContext) marshalNFood2ᚖgithubᚗcomᚋHirotakaUchishibaᚋc
 
 func (ec *executionContext) marshalNFoodLog2githubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐFoodLog(ctx context.Context, sel ast.SelectionSet, v FoodLog) graphql.Marshaler {
 	return ec._FoodLog(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNFoodLog2ᚕᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐFoodLogᚄ(ctx context.Context, sel ast.SelectionSet, v []*FoodLog) graphql.Marshaler {
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNFoodLog2ᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐFoodLog(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
 }
 
 func (ec *executionContext) marshalNFoodLog2ᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐFoodLog(ctx context.Context, sel ast.SelectionSet, v *FoodLog) graphql.Marshaler {
@@ -6870,6 +7568,20 @@ func (ec *executionContext) unmarshalNUserGoalInput2githubᚗcomᚋHirotakaUchis
 func (ec *executionContext) unmarshalNUserProfileInput2githubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐUserProfileInput(ctx context.Context, v any) (UserProfileInput, error) {
 	res, err := ec.unmarshalInputUserProfileInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNWeightLog2githubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐWeightLog(ctx context.Context, sel ast.SelectionSet, v WeightLog) graphql.Marshaler {
+	return ec._WeightLog(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNWeightLog2ᚖgithubᚗcomᚋHirotakaUchishibaᚋcalomeal_mvpᚋbackendᚐWeightLog(ctx context.Context, sel ast.SelectionSet, v *WeightLog) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._WeightLog(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalN__Directive2githubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐDirective(ctx context.Context, sel ast.SelectionSet, v introspection.Directive) graphql.Marshaler {

--- a/backend/models_gen.go
+++ b/backend/models_gen.go
@@ -113,3 +113,10 @@ type UserProfileInput struct {
 	Weight        float64 `json:"weight"`
 	ActivityLevel string  `json:"activityLevel"`
 }
+
+// 体重記録を表す型
+type WeightLog struct {
+	ID       string  `json:"id"`
+	Weight   float64 `json:"weight"`
+	LoggedAt string  `json:"loggedAt"`
+}


### PR DESCRIPTION
## 概要
体重記録機能の実装後に発生したGraphQLコード生成エラーを修正しました。`backend.WeightLog`型が未定義というエラーが解決されました。

## 問題
- `schema.resolvers.go`で`backend.WeightLog`型が未定義エラー
- 体重記録機能のGraphQL型定義が正しく生成されていない
- コンパイルエラーにより開発環境でエラーが表示される

## 修正内容
- `gqlgen generate`を手動実行して`WeightLog`型を生成
- `backend/models_gen.go`に`WeightLog`構造体を追加
- 体重記録機能のGraphQL型定義を完了

## 技術的詳細
- **生成された型**: `WeightLog`構造体（ID, Weight, LoggedAtフィールド）
- **修正ファイル**: `backend/models_gen.go`, `backend/generated.go`
- **影響範囲**: 体重記録機能のGraphQLリゾルバー

## テスト
- [ ] コンパイルエラーが解消されることを確認
- [ ] 体重記録機能が正常に動作することを確認
- [ ] GraphQLスキーマが正しく生成されることを確認

## 関連Issue
- 体重記録機能の実装後のコード生成エラー

## 備考
- この修正により体重記録機能が完全に動作するようになります
- 今後のGraphQLスキーマ変更時は`go generate ./...`の実行を忘れずに