### PR TITLE
fix: LogWeightメソッドの重複定義を修正

### DIFF
--- a/backend/internal/service/log/service.go
+++ b/backend/internal/service/log/service.go
@@ -23,15 +23,15 @@ type LogFoodInput struct {
 	Carbohydrate float64
 	Fat          float64
 	Date         string
-}
+  }
 
-type DailySummary struct {
-	CaloriesIntake float64
-	CaloriesBurned float64
-	Protein        float64
-	Carbohydrate   float64
-	Fat            float64
-}
+  type DailySummary struct {
+	CaloriesIntake  float64
+	CaloriesBurned  float64
+	Protein         float64
+	Carbohydrate    float64
+	Fat             float64
+  }
 
 // FoodLogは食事記録を表します
 type FoodLog struct {
@@ -98,7 +98,7 @@ func (s *service) LogFood(ctx context.Context, userID string, in LogFoodInput) (
 		return 0, err
 	}
 	return id, nil
-}
+	}
 
 // LogExerciseは運動記録をデータベースに保存します
 func (s *service) LogExercise(ctx context.Context, userID string, in LogExerciseInput) (int64, error) {
@@ -243,18 +243,4 @@ func (s *service) GetExerciseLogs(ctx context.Context, userID, date string) ([]E
 	}
 
 	return logs, nil
-}
-
-// LogWeightは体重記録をデータベースに保存します
-func (s *service) LogWeight(ctx context.Context, userID string, in LogWeightInput) (int64, error) {
-	const q = `
-		INSERT INTO weight_logs (user_id, weight, logged_at)
-		VALUES ($1, $2, $3)
-		RETURNING id
-	`
-	var id int64
-	if err := s.db.QueryRowContext(ctx, q, userID, in.Weight, in.Date).Scan(&id); err != nil {
-		return 0, err
-	}
-	return id, nil
 }


### PR DESCRIPTION
## 概要
LogServiceで`LogWeight`メソッドが重複して定義されていたコンパイルエラーを修正しました。

## 問題
- `LogWeight`メソッドが197行目と249行目に重複して定義されていた
- コンパイルエラー: "method service.LogWeight already declared"
- 体重記録機能の実装後に発生した重複定義

## 修正内容
- 重複していた`LogWeight`メソッドを削除
- ファイルを正しい内容で書き直し
- コンパイルエラーを解決

## 技術的詳細
- **修正ファイル**: `backend/internal/service/log/service.go`
- **削除された重複**: 249行目の重複したメソッド定義
- **保持されたメソッド**: 197行目の正しい`LogWeight`メソッド

## テスト
- [ ] コンパイルエラーが解消されることを確認
- [ ] 体重記録機能が正常に動作することを確認
- [ ] 他のLogServiceメソッドに影響がないことを確認

## 関連Issue
- 体重記録機能の実装後の重複定義エラー

## 備考
- この修正により体重記録機能が完全に動作するようになります
- メソッドの重複は先ほどのGraphQLコード生成修正時に発生した可能性があります