### PR TITLE
chore: DEVELOPMENT_PLAN 追加とフェーズ別Issueテンプレート作成（phase0–8）

### DIFF
--- a/.github/ISSUE_TEMPLATE/phase0-foundation.yml
+++ b/.github/ISSUE_TEMPLATE/phase0-foundation.yml
@@ -1,0 +1,18 @@
+name: Phase 0 - 基盤の安定化
+description: ローカル起動、E2E、最小観測性（traceId）
+title: "phase0: 基盤の安定化"
+labels: [phase0]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        目的: ローカルでE2Eを安定実行し、BFFに最小の構造化ログ（traceId）を追加する。
+  - type: checklist
+    attributes:
+      label: 受け入れ基準
+      options:
+        - label: docker-composeで起動し、E2Eが緑
+          required: true
+        - label: BFFログにtraceIdが出力される
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/phase1-graphql.yml
+++ b/.github/ISSUE_TEMPLATE/phase1-graphql.yml
@@ -1,0 +1,18 @@
+name: Phase 1 - 契約の固定化（GraphQL）
+description: スキーマ唯一化、型生成、互換性ルール
+title: "phase1: GraphQL契約の固定化"
+labels: [phase1]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        目的: GraphQLスキーマを唯一の真実源とし、型生成と互換性チェックをパイプラインに組み込む。
+  - type: checklist
+    attributes:
+      label: 受け入れ基準
+      options:
+        - label: スキーマ変更時に型生成がCIで実行される
+          required: true
+        - label: 互換性ポリシーに違反する変更がPRで検出される
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/phase2-grpc.yml
+++ b/.github/ISSUE_TEMPLATE/phase2-grpc.yml
@@ -1,0 +1,18 @@
+name: Phase 2 - gRPC導入（最小）
+description: Proto、最小サービス、BFF差し替え
+title: "phase2: gRPC最小導入"
+labels: [phase2]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        目的: foods.v1.SearchFoods を .proto で定義し、最小サーバとBFFクライアントを実装する。
+  - type: checklist
+    attributes:
+      label: 受け入れ基準
+      options:
+        - label: .proto が存在し、コード生成が通る
+          required: true
+        - label: BFF の searchFood が gRPC 経由で成功
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/phase3-infra.yml
+++ b/.github/ISSUE_TEMPLATE/phase3-infra.yml
@@ -1,0 +1,18 @@
+name: Phase 3 - インフラ dev デプロイ
+description: ECS/ECR/Cloud Map、CIマトリクス
+title: "phase3: devデプロイ基盤"
+labels: [phase3]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        目的: BFF と foodsvc を dev 環境にデプロイし、Cloud Map 経由で疎通させる。
+  - type: checklist
+    attributes:
+      label: 受け入れ基準
+      options:
+        - label: ALB 経由で BFF にアクセスできる
+          required: true
+        - label: BFF→foodsvc の gRPC が成功
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/phase4-services.yml
+++ b/.github/ISSUE_TEMPLATE/phase4-services.yml
@@ -1,0 +1,18 @@
+name: Phase 4 - サービス拡張（logsvc/analytics）
+description: 2サービス抽出、BFFをgRPC化、JWTメタデータ
+title: "phase4: logsvc/analytics 抽出"
+labels: [phase4]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        目的: logs.v1 / analytics.v1 を抽出し、BFF から gRPC で呼び出す。JWT メタデータを標準化する。
+  - type: checklist
+    attributes:
+      label: 受け入れ基準
+      options:
+        - label: 既存E2Eが緑のまま
+          required: true
+        - label: 代表メソッドのコントラクトテスト追加
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/phase5-observability.yml
+++ b/.github/ISSUE_TEMPLATE/phase5-observability.yml
@@ -1,0 +1,18 @@
+name: Phase 5 - 観測性・信頼性
+description: Otel/CloudWatch/X-Ray、タイムアウト/リトライ
+title: "phase5: 観測性/信頼性の基礎"
+labels: [phase5]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        目的: OpenTelemetry と CloudWatch/X-Ray で可観測化し、クライアントのデッドラインと限定リトライを実装する。
+  - type: checklist
+    attributes:
+      label: 受け入れ基準
+      options:
+        - label: p95 レイテンシが可視
+          required: true
+        - label: トレースでリクエスト経路を追跡可能
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/phase6-data.yml
+++ b/.github/ISSUE_TEMPLATE/phase6-data.yml
@@ -1,0 +1,18 @@
+name: Phase 6 - データ責務と移行
+description: 所有権明文化、分離ロードマップ
+title: "phase6: データ責務/移行計画"
+labels: [phase6]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        目的: テーブルの所有権をサービス単位で明文化し、将来のスキーマ分離計画を策定する。
+  - type: checklist
+    attributes:
+      label: 受け入れ基準
+      options:
+        - label: 所有マッピング文書がある
+          required: true
+        - label: 分離/移行手順（ローリング/ロールバック）が定義されている
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/phase7-mobile.yml
+++ b/.github/ISSUE_TEMPLATE/phase7-mobile.yml
@@ -1,0 +1,18 @@
+name: Phase 7 - React Native 最小アプリ
+description: Expo + Amplify + Apollo、dailySummary 表示
+title: "phase7: RN最小アプリ"
+labels: [phase7]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        目的: Expo（TypeScript）で最小アプリを作成し、Cognito 認証後に GraphQL の dailySummary を表示する。
+  - type: checklist
+    attributes:
+      label: 受け入れ基準
+      options:
+        - label: サインイン→ダッシュボード表示
+          required: true
+        - label: dailySummary の数値が表示される
+          required: true
+

--- a/.github/ISSUE_TEMPLATE/phase8-governance.yml
+++ b/.github/ISSUE_TEMPLATE/phase8-governance.yml
@@ -1,0 +1,18 @@
+name: Phase 8 - ガバナンス/品質
+description: 契約互換性ゲート、SAST、Secrets運用
+title: "phase8: ガバナンス/品質の整備"
+labels: [phase8]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        目的: GraphQL/Proto の互換性チェックをCIでブロックし、基本のSASTとSecrets運用を整備する。
+  - type: checklist
+    attributes:
+      label: 受け入れ基準
+      options:
+        - label: 非互換PRがCIで検出/ブロックされる
+          required: true
+        - label: SAST がCIで実行される
+          required: true
+

--- a/docs/DEVELOPMENT_PLAN.md
+++ b/docs/DEVELOPMENT_PLAN.md
@@ -1,0 +1,52 @@
+# 開発工程計画（フェーズ0–8）
+
+本計画は、設計書の要件（GraphQL BFF + gRPC マイクロサービス + React Native + AWS 運用）を満たすための工程分解です。各フェーズは「作業」「成果物」「受け入れ基準（AC）」を明記します。
+
+## フェーズ0 基盤の安定化
+- 作業: ローカル起動、E2Eハッピーパス、最小構造化ログ（traceId）
+- 成果物: 起動手順更新、最小ログ
+- AC: E2E緑、ログにtraceId
+
+## フェーズ1 契約の固定化（GraphQL）
+- 作業: スキーマ唯一化、型生成パイプライン、互換性ルール
+- 成果物: PRチェック項目、codegenスクリプト
+- AC: スキーマ変更時にCIで型生成/影響検出
+
+## フェーズ2 gRPC導入（最小）
+- 作業: Protoツールチェーン、foods.v1.SearchFoods 実装、BFF差替
+- 成果物: .proto / 生成 / サーバ / クライアント
+- AC: ローカルで gRPC 経由 searchFood 成功、テスト追加
+
+## フェーズ3 インフラ dev デプロイ
+- 作業: Cloud Map + 複数ECS、ECR、CIマトリクス
+- 成果物: dev環境に BFF/foodsvc 配置
+- AC: ALB経由でGraphQL、BFF→foodsvc疎通
+
+## フェーズ4 サービス拡張（logsvc/analytics）
+- 作業: logs.v1 / analytics.v1 抽出、BFFをgRPC化、JWTメタデータ伝播
+- 成果物: 2サービスの .proto/実装、BFFクライアント
+- AC: 既存E2E緑、コントラクトテスト
+
+## フェーズ5 観測性・信頼性
+- 作業: OpenTelemetry Collector、タイムアウト/リトライ、CloudWatch/X-Ray
+- 成果物: トレース/メトリクス可視化、基本アラート
+- AC: p95可視、トレースで追跡可能
+
+## フェーズ6 データ責務と移行
+- 作業: テーブル所有権の明文化、スキーマ分離ロードマップ
+- 成果物: 所有マッピング、移行手順
+- AC: 参照/更新境界が明確
+
+## フェーズ7 React Native 最小アプリ
+- 作業: Expo + Amplify + Apollo、dailySummary 表示
+- 成果物: mobile/ 最小構成
+- AC: dev環境BFFからデータ取得/表示
+
+## フェーズ8 ガバナンス/品質
+- 作業: 契約互換性ゲート（GraphQL/Proto）、SAST、Secrets運用
+- 成果物: 互換性ブロックCI、セキュリティ基本
+- AC: 非互換PRはCIで検出
+
+---
+
+進め方と詳細手順は docs/LESSONS.md および各レッスン文書を参照。


### PR DESCRIPTION
## 概要
教材化に向けた開発工程計画とフェーズ別Issueテンプレートの追加

## 実装内容 🛠️
- **開発工程計画**: `docs/DEVELOPMENT_PLAN.md` を新規作成
  - フェーズ0-8の詳細工程（作業・成果物・受け入れ基準）
  - GraphQL BFF + gRPCマイクロサービス + React Native + AWS運用への段階的移行計画
- **Issueテンプレート**: `.github/ISSUE_TEMPLATE/` に9個のテンプレートを追加
  - `phase0-foundation.yml` - 基盤の安定化
  - `phase1-graphql.yml` - GraphQL契約の固定化
  - `phase2-grpc.yml` - gRPC導入（最小）
  - `phase3-infra.yml` - インフラdevデプロイ
  - `phase4-services.yml` - サービス拡張（logsvc/analytics）
  - `phase5-observability.yml` - 観測性・信頼性
  - `phase6-data.yml` - データ責務と移行
  - `phase7-mobile.yml` - React Native最小アプリ
  - `phase8-governance.yml` - ガバナンス/品質

## 設計書との整合性 ✅
- GraphQL 契約の互換性: 影響無（計画文書のみ）
- gRPC/Proto 契約の互換性: 影響無（計画文書のみ）

## スクリーンショット
- なし（文書のみの変更）

## 関連Issue 🔗
- 教材化に向けた開発工程の体系化

## 備考 ✍️
- 各フェーズは独立して実行可能な設計
- ジュニアエンジニアの学習段階に応じた段階的アプローチ
- 各フェーズの受け入れ基準により、進捗の可視化が可能
- Issueテンプレートにより、フェーズごとの作業管理が標準化される