### PR TITLE
fix:パスワードリセット以外の認証関連のE2Eテストをパスするように修正

### DIFF
--- a/frontend/src/hooks/useAuthActions.ts
+++ b/frontend/src/hooks/useAuthActions.ts
@@ -101,6 +101,9 @@ export const useAuthActions = () => {
         };
         localStorage.setItem('dev-user', JSON.stringify(devUser));
         
+        // 認証状態変更イベントを発火
+        window.dispatchEvent(new CustomEvent('authStateChange'));
+        
         return {
           isSignUpComplete: true,
           userId: devUser.userId,

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -94,7 +94,7 @@ test.describe('認証機能のテスト', () => {
     await page.click('text=パスワードを忘れた場合');
     
     // パスワードリセット画面が表示されることを確認
-    await expect(page.locator('h1')).toContainText('パスワードリセット');
+    await expect(page.locator('h2')).toContainText('パスワードリセット');
     
     // メールアドレスを入力
     await page.fill('input[type="email"]', 'test@example.com');

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -53,21 +53,34 @@ test.describe('認証機能のテスト', () => {
     await expect(page.locator('h1')).toContainText('サインアップ');
     
     // 既存ユーザーでサインアップを試行
-    await page.fill('input[placeholder*="お名前"]', 'テストユーザー');
+    await page.fill('input[type="text"]', 'テストユーザー');
     await page.fill('input[type="email"]', 'test@example.com');
     await page.fill('input[type="password"]', 'password123');
-    await page.fill('input[placeholder*="確認"]', 'password123');
+    await page.fill('input[id="confirmPassword"]', 'password123');
     await page.click('button[type="submit"]');
     
     // 既存ユーザーエラーが表示されることを確認
     await expect(page.locator('text=このメールアドレスは既に登録されています')).toBeVisible();
     
     // 新しいユーザーでサインアップを試行
-    await page.fill('input[placeholder*="お名前"]', '新規ユーザー');
+    await page.fill('input[type="text"]', '新規ユーザー');
     await page.fill('input[type="email"]', 'newuser@example.com');
     await page.fill('input[type="password"]', 'newpassword123');
-    await page.fill('input[placeholder*="確認"]', 'newpassword123');
+    await page.fill('input[id="confirmPassword"]', 'newpassword123');
+    
+    // コンソールログを監視
+    page.on('console', msg => console.log('PAGE LOG:', msg.text()));
+    
     await page.click('button[type="submit"]');
+    
+    // サインアップ処理の完了を待機
+    await page.waitForTimeout(2000);
+    
+    // 認証状態の更新を待機
+    await page.waitForFunction(() => {
+      const authState = window.localStorage.getItem('dev-user');
+      return authState !== null;
+    }, { timeout: 5000 });
     
     // ダッシュボードにリダイレクトされることを確認
     await page.waitForURL('/dashboard', { timeout: 10000 });


### PR DESCRIPTION
## 概要
認証機能のE2Eテストが失敗していた問題を解決し、ログイン・サインアップ機能のテストが正常にパスするように修正しました。パスワードリセット機能以外の認証関連E2Eテストの安定性を向上させています。

## 問題
- E2Eテストで認証機能が正常に動作しない
- サインアップ時の認証状態変更イベントが発火されていない
- ログイン・サインアップ後のリダイレクトが正しく動作しない
- CORS設定によりフロントエンドとバックエンドの通信が失敗
- Playwrightの設定とフロントエンドサーバーのポートが不一致

## 修正
- **CORS設定の拡張**: `backend/cmd/server/main.go`で`AllowedOrigins`に`http://localhost:5173-5176`を追加し、動的に割り当てられるフロントエンドポートに対応
- **認証状態管理の改善**: `frontend/src/hooks/useAuthActions.ts`でサインアップ成功時に`authStateChange`イベントを発火するよう修正
- **認証フローの統一**: ログイン・サインアップ両方で認証状態変更イベントを適切に発火し、`AuthContext`が状態変更を検知できるよう改善

### E2Eテストの修正
- **認証テストの安定化**: `tests/e2e/auth.spec.ts`でログイン・サインアップテストに適切な待機処理を追加
- **認証状態の待機**: `localStorage`の`dev-user`設定完了を待機する`page.waitForFunction`を追加
- **コンソールログ監視**: デバッグ用のコンソールログ監視を追加
- **Playwright設定の修正**: `playwright.config.ts`の`baseURL`を`http://localhost:5176`に更新

## テスト結果
- ✅ ログイン機能のE2Eテスト: パス
- ✅ サインアップ機能のE2Eテスト: パス
- ✅ 認証状態の適切な管理: 確認済み
- ✅ ダッシュボードへのリダイレクト: 正常動作