### PR TITLE
fix: サインアップ後の遷移先をオンボーディングに変更し、E2Eテストを対応

### DIFF
--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -55,7 +55,7 @@ export const ProtectedRoute: React.FC<ProtectedRouteProps> = ({
 
   // 認証済みユーザーが認証不要なページにアクセスした場合
   if (!requireAuth && isAuthenticated) {
-    const redirectPath = redirectTo || '/dashboard';
+    const redirectPath = redirectTo || '/onboarding';
     return <Navigate to={redirectPath} replace />;
   }
 

--- a/frontend/src/features/onboarding/OnboardingPage.tsx
+++ b/frontend/src/features/onboarding/OnboardingPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { gql } from '@apollo/client';
 import { useMutation } from '@apollo/client/react';
 
@@ -13,6 +14,8 @@ const COMPLETE_ONBOARDING_MUTATION = gql`
 `;
 
 export const OnboardingPage = () => {
+  const navigate = useNavigate();
+  
   // プロフィール情報の状態
   const [height, setHeight] = useState('');
   const [weight, setWeight] = useState('');
@@ -46,7 +49,8 @@ export const OnboardingPage = () => {
       }
     }).then((response: any) => {
       console.log('Onboarding Succeeded:', response.data);
-      // TODO: 成功したらダッシュボードへリダイレクトする処理を後で実装します
+      // 成功したらダッシュボードへリダイレクト
+      navigate('/dashboard');
     }).catch((err: any) => {
       console.error('Onboarding Failed:', err);
     });

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -82,9 +82,9 @@ test.describe('認証機能のテスト', () => {
       return authState !== null;
     }, { timeout: 5000 });
     
-    // ダッシュボードにリダイレクトされることを確認
-    await page.waitForURL('/dashboard', { timeout: 10000 });
-    await expect(page.locator('h1')).toContainText('ダッシュボード');
+    // オンボーディングにリダイレクトされることを確認
+    await page.waitForURL('/onboarding', { timeout: 10000 });
+    await expect(page.locator('h1')).toContainText('ようこそ！目標を設定しましょう');
   });
 
   test('パスワードリセット機能', async ({ page }) => {

--- a/tests/e2e/logging.spec.ts
+++ b/tests/e2e/logging.spec.ts
@@ -10,8 +10,17 @@ test.describe('記録機能のテスト', () => {
     await page.fill('input[type="password"]', 'password123');
     await page.click('button[type="submit"]');
     
-    // ダッシュボードにリダイレクトされるまで待機
-    await page.waitForURL('/dashboard', { timeout: 10000 });
+    // 認証状態の更新を待機
+    await page.waitForFunction(() => {
+      const authState = window.localStorage.getItem('dev-user');
+      return authState !== null;
+    }, { timeout: 5000 });
+    
+    // ログイン処理の完了を待機
+    await page.waitForTimeout(1000);
+    
+    // ダッシュボードに直接遷移
+    await page.goto('/dashboard');
     
     // ダッシュボードが表示されるまで待機
     await expect(page.locator('h1')).toContainText('ダッシュボード', { timeout: 10000 });

--- a/tests/e2e/logging.spec.ts
+++ b/tests/e2e/logging.spec.ts
@@ -19,8 +19,22 @@ test.describe('記録機能のテスト', () => {
     // ログイン処理の完了を待機
     await page.waitForTimeout(1000);
     
-    // ダッシュボードに直接遷移
-    await page.goto('/dashboard');
+    // オンボーディングページに遷移することを確認
+    await page.waitForURL('/onboarding', { timeout: 10000 });
+    await expect(page.locator('h1')).toContainText('ようこそ！目標を設定しましょう');
+    
+    // オンボーディング情報を入力
+    await page.fill('input[id="height"]', '170');
+    await page.fill('input[id="weight"]', '70');
+    await page.selectOption('select[id="activityLevel"]', 'normal');
+    await page.fill('input[id="targetWeight"]', '65');
+    await page.fill('input[id="targetDate"]', '2025-12-31');
+    
+    // オンボーディングを完了
+    await page.click('button[type="submit"]');
+    
+    // ダッシュボードに遷移するまで待機
+    await page.waitForURL('/dashboard', { timeout: 10000 });
     
     // ダッシュボードが表示されるまで待機
     await expect(page.locator('h1')).toContainText('ダッシュボード', { timeout: 10000 });


### PR DESCRIPTION
## 概要
サインアップ後の遷移先をダッシュボードからオンボーディングに変更し、関連するE2Eテストとオンボーディングフローを実装。

## 修正内容

### サインアップ機能の改善
- **遷移先変更**: サインアップ完了後のリダイレクト先を `/dashboard` から `/onboarding` に変更
- **アラートメッセージ更新**: 「ダッシュボードに移動します」→「オンボーディングに移動します」
- **認証済みユーザーのリダイレクト**: サインアップページにアクセスした認証済みユーザーも `/onboarding` にリダイレクト

### オンボーディングフローの完全実装
- **ダッシュボード遷移処理**: オンボーディング完了後に `/dashboard` に遷移する機能を追加
- **useNavigateフック**: React Routerのナビゲーション機能を統合

### E2Eテストの対応
- **auth.spec.ts**: サインアップ機能のテストをオンボーディング遷移に対応
- **logging.spec.ts**: 記録機能テストをオンボーディングフローに対応
  - ログイン → オンボーディング → ダッシュボード → 記録機能テストの流れを実装
- **ProtectedRoute**: 認証済みユーザーのデフォルトリダイレクト先を `/onboarding` に変更

## 技術的詳細

### 変更ファイル
- `frontend/src/features/auth/SignUpPage.tsx`: サインアップ後の遷移先変更
- `frontend/src/features/onboarding/OnboardingPage.tsx`: ダッシュボード遷移処理追加
- `frontend/src/components/ProtectedRoute.tsx`: デフォルトリダイレクト先変更
- `tests/e2e/auth.spec.ts`: サインアップ機能テストの修正
- `tests/e2e/logging.spec.ts`: オンボーディングフロー対応

### 改善点
- **ユーザーエクスペリエンス向上**: 新規ユーザーは適切なオンボーディングフローを経由
- **テストの安定性**: オンボーディングフローを含む完全なE2Eテスト
- **一貫性**: 認証済みユーザーのリダイレクト先が統一

## テスト
- [x] サインアップ機能のE2Eテストが正常に動作
- [x] 記録機能のE2Eテストがオンボーディングフローを経由して動作
- [x] オンボーディング完了後のダッシュボード遷移が正常に動作
- [x] 認証済みユーザーのリダイレクトが適切に動作

## 関連Issue
- サインアップ後の遷移先改善
- オンボーディングフローの完全実装
- E2Eテストの安定性向上