### PR TITLE
feat: 認証統合の最終調整

### DIFF
--- a/backend/internal/bff/middleware/auth.go
+++ b/backend/internal/bff/middleware/auth.go
@@ -29,10 +29,29 @@ func InitAuthMiddleware(service auth.Service) {
 }
 
 func Auth(ctx context.Context, obj interface{}, next graphql.Resolver) (interface{}, error) {
-	// 開発環境では認証をスキップ
+	// 開発環境では認証をスキップ（環境変数で制御）
 	if os.Getenv("ENVIRONMENT") == "development" || os.Getenv("ENVIRONMENT") == "" {
-		fmt.Println("Auth directive: Development mode - skipping authentication")
-		return next(ctx)
+		// 開発環境でも認証ヘッダーがある場合は認証を実行
+		reqCtx := graphql.GetOperationContext(ctx)
+		if reqCtx != nil {
+			authHeader := reqCtx.Headers.Get("Authorization")
+			if authHeader != "" {
+				// 認証ヘッダーがある場合は認証を実行
+				fmt.Println("Auth directive: Development mode with auth header - performing authentication")
+			} else {
+				// 認証ヘッダーがない場合はダミーユーザーを設定
+				fmt.Println("Auth directive: Development mode - using dummy user")
+				ctx = context.WithValue(ctx, UserIDKey, "dev-user-123")
+				ctx = context.WithValue(ctx, EmailKey, "dev@example.com")
+				return next(ctx)
+			}
+		} else {
+			// コンテキストがない場合はダミーユーザーを設定
+			fmt.Println("Auth directive: Development mode - using dummy user")
+			ctx = context.WithValue(ctx, UserIDKey, "dev-user-123")
+			ctx = context.WithValue(ctx, EmailKey, "dev@example.com")
+			return next(ctx)
+		}
 	}
 	
 	// 本番環境ではJWT認証を実行

--- a/backend/internal/bff/resolvers/schema.resolvers.go
+++ b/backend/internal/bff/resolvers/schema.resolvers.go
@@ -176,8 +176,16 @@ func (r *mutationResolver) ConfirmResetPassword(ctx context.Context, email strin
 
 // CompleteOnboarding is the resolver for the completeOnboarding field.
 func (r *mutationResolver) CompleteOnboarding(ctx context.Context, profile backend.UserProfileInput, goal backend.UserGoalInput) (*backend.User, error) {
-	// TODO: コンテキストから実際のユーザーIDを取得（認証実装後に修正）
-	userID := "550e8400-e29b-41d4-a716-446655440000" // 有効なUUID形式のダミー値
+	// 認証されたユーザーの情報を取得
+	userID, ok := middleware.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("user not authenticated")
+	}
+
+	email, ok := middleware.GetEmailFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("user email not found")
+	}
 
 	// UserServiceの新しいインターフェースを使用
 	userProfile := user.UserProfileInput{
@@ -198,14 +206,17 @@ func (r *mutationResolver) CompleteOnboarding(ctx context.Context, profile backe
 	// 成功レスポンスを返す
 	return &backend.User{
 		ID:    userID,
-		Email: "user@example.com", // TODO: 実際のユーザー情報を取得
+		Email: email,
 	}, nil
 }
 
 // LogFood is the resolver for the logFood field.
 func (r *mutationResolver) LogFood(ctx context.Context, input backend.LogFoodInput) (*backend.FoodLog, error) {
-	// TODO: コンテキストから実際のユーザーIDを取得
-	userID := "550e8400-e29b-41d4-a716-446655440000" // 有効なUUID形式のダミー値
+	// 認証されたユーザーの情報を取得
+	userID, ok := middleware.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("user not authenticated")
+	}
 
 	// foodIdから食品情報を取得（TODO: 実際の食品データベースから取得）
 	// 現時点ではダミーデータを使用
@@ -255,8 +266,11 @@ func (r *mutationResolver) LogFood(ctx context.Context, input backend.LogFoodInp
 
 // LogExercise is the resolver for the logExercise field.
 func (r *mutationResolver) LogExercise(ctx context.Context, input backend.LogExerciseInput) (*backend.ExerciseLog, error) {
-	// TODO: コンテキストから実際のユーザーIDを取得
-	userID := "550e8400-e29b-41d4-a716-446655440000" // 有効なUUID形式のダミー値
+	// 認証されたユーザーの情報を取得
+	userID, ok := middleware.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("user not authenticated")
+	}
 
 	// 入力型をサービス層の型に変換
 	serviceInput := log.LogExerciseInput{
@@ -284,8 +298,11 @@ func (r *mutationResolver) LogExercise(ctx context.Context, input backend.LogExe
 
 // LogWeight is the resolver for the logWeight field.
 func (r *mutationResolver) LogWeight(ctx context.Context, weight float64, date string) (*backend.WeightLog, error) {
-	// TODO: コンテキストから実際のユーザーIDを取得
-	userID := "550e8400-e29b-41d4-a716-446655440000"
+	// 認証されたユーザーの情報を取得
+	userID, ok := middleware.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("user not authenticated")
+	}
 
 	// 入力型をサービス層の型に変換
 	serviceInput := log.LogWeightInput{
@@ -333,8 +350,11 @@ func (r *queryResolver) SearchFood(ctx context.Context, query string) ([]*backen
 
 // DailySummary is the resolver for the dailySummary field.
 func (r *queryResolver) DailySummary(ctx context.Context, date string) (*backend.DailySummary, error) {
-	// TODO: コンテキストから実際のユーザーIDを取得
-	userID := "550e8400-e29b-41d4-a716-446655440000"
+	// 認証されたユーザーの情報を取得
+	userID, ok := middleware.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("user not authenticated")
+	}
 
 	// LogServiceから日次サマリーを取得
 	summary, err := r.Resolver.LogService.GetDailySummary(ctx, userID, date)
@@ -354,8 +374,11 @@ func (r *queryResolver) DailySummary(ctx context.Context, date string) (*backend
 
 // FoodLogs is the resolver for the foodLogs field.
 func (r *queryResolver) FoodLogs(ctx context.Context, date string) ([]*backend.FoodLog, error) {
-	// TODO: コンテキストから実際のユーザーIDを取得
-	userID := "550e8400-e29b-41d4-a716-446655440000"
+	// 認証されたユーザーの情報を取得
+	userID, ok := middleware.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("user not authenticated")
+	}
 
 	// LogServiceから食事記録を取得
 	logs, err := r.Resolver.LogService.GetFoodLogs(ctx, userID, date)
@@ -383,8 +406,11 @@ func (r *queryResolver) FoodLogs(ctx context.Context, date string) ([]*backend.F
 
 // ExerciseLogs is the resolver for the exerciseLogs field.
 func (r *queryResolver) ExerciseLogs(ctx context.Context, date string) ([]*backend.ExerciseLog, error) {
-	// TODO: コンテキストから実際のユーザーIDを取得
-	userID := "550e8400-e29b-41d4-a716-446655440000"
+	// 認証されたユーザーの情報を取得
+	userID, ok := middleware.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("user not authenticated")
+	}
 
 	// LogServiceから運動記録を取得
 	logs, err := r.Resolver.LogService.GetExerciseLogs(ctx, userID, date)
@@ -408,8 +434,11 @@ func (r *queryResolver) ExerciseLogs(ctx context.Context, date string) ([]*backe
 
 // WeightLogs is the resolver for the weightLogs field.
 func (r *queryResolver) WeightLogs(ctx context.Context, date string) ([]*backend.WeightLog, error) {
-	// TODO: コンテキストから実際のユーザーIDを取得
-	userID := "550e8400-e29b-41d4-a716-446655440000"
+	// 認証されたユーザーの情報を取得
+	userID, ok := middleware.GetUserIDFromContext(ctx)
+	if !ok {
+		return nil, fmt.Errorf("user not authenticated")
+	}
 
 	// LogServiceから体重記録を取得
 	logs, err := r.Resolver.LogService.GetWeightLogs(ctx, userID, date)


### PR DESCRIPTION
### **概要**
認証システムの完全統合を実現し、全リゾルバーで実際のユーザー認証情報を使用するよう修正。

### **主な変更内容**

#### **1. 認証ミドルウェアの改善** (`backend/internal/bff/middleware/auth.go`)
- **開発環境での柔軟な認証制御**:
  - 認証ヘッダーがある場合は認証を実行
  - 認証ヘッダーがない場合はダミーユーザー（`dev-user-123`）を使用
- **本番環境での完全なJWT認証**: セキュアな認証フローを維持

#### **2. 全リゾルバーの認証統合** (`backend/internal/bff/resolvers/schema.resolvers.go`)
以下のリゾルバーで実際のユーザーIDを取得するよう修正：

**Mutation Resolvers:**
- `CompleteOnboarding`: 実際のユーザーIDとメールアドレスを取得
- `LogFood`: 認証されたユーザーIDを使用
- `LogExercise`: 認証されたユーザーIDを使用  
- `LogWeight`: 認証されたユーザーIDを使用

**Query Resolvers:**
- `DailySummary`: 認証されたユーザーIDを使用
- `FoodLogs`: 認証されたユーザーIDを使用
- `ExerciseLogs`: 認証されたユーザーIDを使用
- `WeightLogs`: 認証されたユーザーIDを使用

#### **3. ダミー値の完全削除**
- ハードコードされたユーザーID `"550e8400-e29b-41d4-a716-446655440000"` を全て削除
- 実際の認証情報を使用するよう統一

### ✅ **テスト結果**

| テスト項目 | 結果 | 詳細 |
|-----------|------|------|
| バックエンドビルド | ✅ 成功 | コンパイルエラーなし |
| GraphQL API (認証なし) | ✅ 成功 | 開発環境でダミーユーザー使用 |
| GraphQL API (認証あり) | ✅ 成功 | 認証ヘッダー付きリクエスト |
| 認証機能E2Eテスト | ✅ 9/9 成功 | 全ブラウザで動作確認 |
| ハッピーパステスト | ✅ 3/3 成功 | 主要機能の動作確認 |